### PR TITLE
chore: add blocking feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,17 @@ license = "Apache-2.0"
 keywords = ["gorse", "machine-learning", "recommender-system"]
 categories = ["algorithms", "science"]
 
+[features]
+default = ["blocking"]
+blocking = ["reqwest/blocking"]
+
 [dependencies]
-reqwest = { version = "0.13", default-features = false, features = ["blocking", "json"] }
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serial_test = "3.2.0"
 thiserror = "2.0.17"
 
 [dev-dependencies]
 chrono = "0.4.23"
+serial_test = "3.2.0"
 tokio = { version = "1.22.0", features = ["macros"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,7 @@ mod tests {
     }
 }
 
+#[cfg(feature = "blocking")]
 pub mod blocking {
     use reqwest::blocking::Client;
     use serde::{Deserialize, Serialize};


### PR DESCRIPTION
This PR adds a "blocking" feature to avoid introducing unnecessary dependencies in purely asynchronous environments.
To maintain backward compatibility, the blocking feature is currently enabled by default.